### PR TITLE
Use a proper Cache-Control if m_ShouldCache is false

### DIFF
--- a/src/Web/WebRendererSchemeHandler.cpp
+++ b/src/Web/WebRendererSchemeHandler.cpp
@@ -368,6 +368,8 @@ void WebRendererSchemeHandler::GetResponseHeaders(CefRefPtr<CefResponse> p_Respo
 
 	if (m_ShouldCache)
 		s_Headers.insert(std::make_pair("Cache-Control", "public, max-age=0"));
+	else
+		s_Headers.insert(std::make_pair("Cache-Control", "private, max-age=0, no-cache"));
 
 	s_Headers.insert(std::make_pair("Content-Length", boost::lexical_cast<std::string>(m_RequestedLength).c_str()));
 

--- a/web/screens/console/console.js
+++ b/web/screens/console/console.js
@@ -207,10 +207,6 @@ $(window).load(function () {
         focusInput();
     });
 
-    $("#button-reload").click(function () {
-        location.reload();
-    });
-
     $("#button-size").click(function () {
         setConsoleSize(0);
         focusInput();

--- a/web/screens/console/index.html
+++ b/web/screens/console/index.html
@@ -24,7 +24,6 @@
                 </div>
                 <div id="button-help" class="box transparent button">Help</div>
                 <div id="button-clear" class="box transparent button">Clear</div>
-                <div id="button-reload" class="box transparent button">Reload</div>
                 <div id="button-size" class="box transparent button">Size</div>
                 <div id="button-hide" class="box transparent button">Close</div>
             </div>


### PR DESCRIPTION
### Proposed changes in this pull request:

1.

2.

3.

### Why should this pull request be merged?

### Have you tested this on your own and/or in a game with other people?

This fixes some issues with screen code getting cached when it shouldn't be, making testing difficult because reloads don't work correctly. This also removes the Reload button from the console because it's not something that end users should need to care about. Use webdebug mode if you need to work on the console.