### PR TITLE
Disallow setting internal variables with commands

### DIFF
--- a/src/CommandMap.hpp
+++ b/src/CommandMap.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <Windows.h>
 #include <vector>
 #include <deque>
 
@@ -29,11 +28,6 @@ enum CommandFlags
 };
 
 typedef bool (*CommandUpdateFunc)(const std::vector<std::string>& Arguments, std::string& returnInfo);
-
-namespace
-{
-	PCHAR* CommandLineToArgvA(PCHAR CmdLine, int* _argc);
-}
 
 namespace Modules
 {

--- a/src/Modules/ModuleServer.hpp
+++ b/src/Modules/ModuleServer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ModuleBase.hpp"
+#include <cstdint>
 
 namespace Modules
 {
@@ -26,7 +27,7 @@ namespace Modules
 		Command* VarServerDualWieldEnabledClient;
 		Command* VarServerAssassinationEnabled;
 
-		BYTE SyslinkData[0x176];
+		uint8_t SyslinkData[0x176];
 
 		ModuleServer();
 	};


### PR DESCRIPTION
### Proposed changes in this pull request:

1.

2.

3.

### Why should this pull request be merged?

### Have you tested this on your own and/or in a game with other people?

This prevents people from potentially abusing the web overlay to change internal variables. Internal variables can still be read.